### PR TITLE
Fix example of setting metersPerUnit and upAxis on SdfLayer

### DIFF
--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -1065,9 +1065,9 @@ layer.framesPerSecond = 25
 layer.startTimeCode = time_samples[0]
 layer.endTimeCode = time_samples[-1]
 # Scene Unit Scale
-layer.SetInfo(UsdGeom.Tokens.metersPerUnit, UsdGeom.LinearUnits.centimeters)
+layer.pseudoRoot.SetInfo(UsdGeom.Tokens.metersPerUnit, UsdGeom.LinearUnits.centimeters)
 # Scene Up Axis
-layer.SetInfo(UsdGeom.Tokens.upAxis, UsdGeom.Tokens.y) # Or  UsdGeom.Tokens.z
+layer.pseudoRoot.SetInfo(UsdGeom.Tokens.upAxis, UsdGeom.Tokens.y) # Or  UsdGeom.Tokens.z
 #// ANCHOR_END: metadataLayerMetrics
 
 #// ANCHOR: debuggingTokens


### PR DESCRIPTION
It seems that `Sdf.Layer.SetInfo` does not exist.

```python
#     layer.SetInfo(UsdGeom.Tokens.upAxis, UsdGeom.Tokens.y)
# AttributeError: 'Layer' object has no attribute 'SetInfo'
```
I see `SetInfo`on `Sdf.Spec` [here](https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest/pxr/Sdf.html#pxr.Sdf.Spec.SetInfo)  but not on `Sdf.Layer`.

It has to be on the Layer's pseudoRoot instead:
```python
layer.pseudoRoot.SetInfo(UsdGeom.Tokens.upAxis, UsdGeom.Tokens.y)
```

Saves to:
```usda
#usda 1.0
(
    upAxis = "Y"
)
```

---

I edited the file via Github - I'm not sure why it added the new line at the end (not sure if you have issues with that).