### PR TITLE
Fix two typos in the Asset Resolver code examples

### DIFF
--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -1243,7 +1243,7 @@ from pxr import Ar
 resolver = Ar.GetResolver()
 resolved_path = resolver.Resolve("someAssetIdentifier")
 # Get the Python string
-resolved_path_str = path.GetPathString() # Or str(resolved_path)
+resolved_path_str = resolved_path.GetPathString() # Or str(resolved_path)
 #// ANCHOR_END: assetResolverResolve
 
 #// ANCHOR: assetResolverAssetPath

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -1235,7 +1235,7 @@ resolver.RefreshContext(context_collection)
 #// ANCHOR: assetResolverStageContextResolve
 resolved_path = stage.ResolveIdentifierToEditTarget("someAssetIdentifier")
 # Get the Python string
-resolved_path_str = path.GetPathString() # Or str(resolved_path)
+resolved_path_str = resolved_path.GetPathString() # Or str(resolved_path)
 #// ANCHOR_END: assetResolverStageContextResolve
 
 #// ANCHOR: assetResolverResolve


### PR DESCRIPTION
Hi,

In section 2.4.4 Asset Resolver, the two code examples  `assetResolverResolve` and `assetResolverStageContextResolve` looks to have a typo on the last line. Both of the are referencing an undefined variable `path` instead of the `resolved_path` defined above. This PR fixes those two typos.