### PR TITLE
docs+fix: Correct logic issues and improve clarity in comments and examples

### DIFF
--- a/code/core/composition.py
+++ b/code/core/composition.py
@@ -222,7 +222,7 @@ print(root_layer.subLayerOffsets) # Returns: [Sdf.LayerOffset(10, 2), Sdf.LayerO
 # If we want to sublayer on the active layer, we just add it there.
 layer_c = Sdf.Layer.CreateAnonymous()
 active_layer = stage.GetEditTarget().GetLayer()
-root_layer.subLayerPaths.append(layer_c.identifier)
+active_layer.subLayerPaths.append(layer_c.identifier)
 #// ANCHOR_END: compositionArcSublayer
 
 

--- a/code/core/composition.py
+++ b/code/core/composition.py
@@ -208,7 +208,7 @@ root_layer.subLayerPaths.append(layer_a.identifier)
 root_layer.subLayerPaths.append(layer_b.identifier)
 # Once we have added the sublayers, we can also access their layer offsets:
 print(root_layer.subLayerOffsets) # Returns: [Sdf.LayerOffset(), Sdf.LayerOffset()]
-# Since layer offsets are ready only copies, we need to assign a newly created 
+# Since layer offsets are read only copies, we need to assign a newly created 
 # layer offset if we want to modify them. We also can't replace the whole list, as
 # it needs to keep a pointer to the array.
 layer_offset_a = root_layer.subLayerOffsets[0]

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -3699,7 +3699,7 @@ tire_diameter_attr_spec = Sdf.AttributeSpec(bicycle_prim_spec, "tire:diameter", 
 tire_diameter_attr_spec.connectionPathList.explicitItems = [tire_size_attr_spec.path]
 def traversal_kernel(path):
     if path.IsTargetPath():
-        print(">> IsTargetPath", path) 
+        print("IsTargetPath", path) 
 layer.Traverse(layer.pseudoRoot.path, traversal_kernel)
 """ Returns:
 IsTargetPath /set/yard/bicycle.tire:diameter[/set/yard/bicycle.tire:size]

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -3388,7 +3388,7 @@ instance = cls()
 
 ##### Types - pxr.Vt.Type Registry #####
 from pxr import Vt
-# For Python usage, the only thing of interest for data types in the Vt.Type module are the `*Array`ending classes.`
+# For Python usage, the only thing of interest for data types in the Vt.Type module are the `*Array`ending classes.
 # You will only use these array types to handle the auto conversion
 # form buffer protocol arrays like numpy arrays, the rest is auto converted and you don't need
 # to worry about it. Normal Python lists do not support the buffer protocol.

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -3570,7 +3570,7 @@ layer_file_path = os.path.expanduser("~/Desktop/layer_identifier_example.usd")
 layer = Sdf.Layer.CreateNew(layer_file_path)
 print(layer.dirty) # Returns: False
 ## Our layers are marked as "dirty" (edited) as soon as we make an edit.
-prin_spec = Sdf.CreatePrimInLayer(layer, Sdf.Path("/pig"))
+prim_spec = Sdf.CreatePrimInLayer(layer, Sdf.Path("/pig"))
 print(layer.dirty) # Returns: True
 layer.Save()
 # Only edited (dirty) layers are saved, when layer.Save() is called
@@ -3591,7 +3591,7 @@ layer.TransferContent(layer.FindOrOpen((layer_file_path)))
 # this is quite usefull for debugging and inspecting the active layer.
 # layer.ImportFromString(other_layer.ExportAsString())
 layer = Sdf.Layer.CreateAnonymous()
-prin_spec = Sdf.CreatePrimInLayer(layer, Sdf.Path("/pig"))
+prim_spec = Sdf.CreatePrimInLayer(layer, Sdf.Path("/pig"))
 print(layer.ExportToString())
 # Returns:
 """

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -3151,7 +3151,10 @@ print(Usd.CollectionAPI.GetAllCollections(set_prim)) # Returns: [Usd.CollectionA
 print(Usd.CollectionAPI.GetCollection(set_prim, "vehicles")) # Returns: Usd.CollectionAPI(Usd.Prim(</set>), 'vehicles')
 collection_query = collection_api.ComputeMembershipQuery()
 print(collection_api.ComputeIncludedPaths(collection_query, stage))
-# Returns: [Sdf.Path('/set'), Sdf.Path('/set/garage'), Sdf.Path('/set/garage/car'), Sdf.Path('/set/yard')]
+# Returns: 
+# [Sdf.Path('/set'), Sdf.Path('/set/garage'), Sdf.Path('/set/garage/boat'),
+#  Sdf.Path('/set/garage/car'), Sdf.Path('/set/garage/helicopter'),
+#  Sdf.Path('/set/garage/tractor'), Sdf.Path('/set/yard')]
 # Set it to explicit only
 collection_api.GetExpansionRuleAttr().Set(Usd.Tokens.explicitOnly)
 collection_query = collection_api.ComputeMembershipQuery()

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -429,7 +429,7 @@ print(prim_spec.name) # Returns: "bicycle"
 # If you want to batch-rename, you should use the Sdf.BatchNamespaceEdit class, see our explanation [here]()
 prim_spec.name = "coolBicycle"
 print(prim_spec.nameParent) # Returns: Sdf.PrimSpec("/set")
-print(prim_spec.nameParent.nameChildren) # Returns: {'coolCube': Sdf.Find('anon:0x7f6e5a0e3c00:LOP:/stage/pythonscript3', '/set/coolBicycle')}
+print(prim_spec.nameParent.nameChildren) # Returns: {'coolBicycle': Sdf.Find('anon:0x7f6e5a0e3c00:LOP:/stage/pythonscript3', '/set/coolBicycle')}
 print(prim_spec.layer) # Returns: The active layer object the spec is on.
 #// ANCHOR_END: dataContainerPrimHierarchy
 
@@ -551,7 +551,7 @@ prim_spec = Sdf.CreatePrimInLayer(layer, prim_path)
 prim_spec.active = False
 # prim_spec.ClearActive()
 ## Visibility: Controls the visiblity for render delegates (subhierarchy will still be loaded)
-visibility_attr_spec = Sdf.AttributeSpec(prim_spec, UsdGeom.Tokens.purpose, Sdf.ValueTypeNames.Token)
+visibility_attr_spec = Sdf.AttributeSpec(prim_spec, UsdGeom.Tokens.visibility, Sdf.ValueTypeNames.Token)
 visibility_attr_spec.default = UsdGeom.Tokens.invisible
 ## Purpose: Controls if the prim is visible for what the renderer requested.
 purpose_attr_spec = Sdf.AttributeSpec(prim_spec, UsdGeom.Tokens.purpose, Sdf.ValueTypeNames.Token)
@@ -626,7 +626,7 @@ box_prim_path = Sdf.Path("/box")
 box_prim_spec = Sdf.CreatePrimInLayer(layer, box_prim_path)
 box_prim_spec.specifier = Sdf.SpecifierDef
 rel_spec = Sdf.RelationshipSpec(prim_spec, "proxyPrim")
-rel_spec.targetPathList.explicitItems = [prim_path]
+rel_spec.targetPathList.explicitItems = [box_prim_path]
 # Get all authored properties (in the active layer only)
 print(prim_spec.properties)
 # Returns:
@@ -2543,9 +2543,9 @@ attr_spec = Sdf.AttributeSpec(prim_spec, "someAssetPathArray", Sdf.ValueTypeName
 attr_spec.default = Sdf.AssetPathArray(["testA.usd", "testB.usd"])
 # Creating an attribute spec with the same data type as an existing attribute (spec)
 # is as easy as passing in the type name from the existing attribute (spec)
-same_type_attr_spec = Sdf.AttributeSpec(prim_spec, "tire:size", attr.GetTypeName())
+same_type_attr_spec = Sdf.AttributeSpec(prim_spec, "tire:radius", attr.GetTypeName())
 # Or
-same_type_attr_spec = Sdf.AttributeSpec(prim_spec, "tire:size", attr_spec.typeName)
+same_type_attr_spec = Sdf.AttributeSpec(prim_spec, "tire:radius", attr_spec.typeName)
 #// ANCHOR_END: attributeDataTypeRole
 
 

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -2757,7 +2757,7 @@ print(UsdGeom.Primvar.IsPrimvar(attr)) # Returns: True
 # This returns an instance of UsdGeom.Primvar
 primvar_api = UsdGeom.PrimvarsAPI(prim)
 primvar = primvar_api.CreatePrimvar("height", Sdf.ValueTypeNames.StringArray)
-print(UsdGeom.Primvar.IsPrimvar(primvar))  # Returns: False
+print(UsdGeom.Primvar.IsPrimvar(primvar))  # Returns: True
 print(primvar.GetPrimvarName()) # Returns: "height"
 primvar.Set(["testA", "testB"])
 print(primvar.ComputeFlattened()) # Returns: ["testA", "testB"]

--- a/code/core/elements.py
+++ b/code/core/elements.py
@@ -3564,6 +3564,7 @@ layer.endTimeCode = time_samples[-1]
 # Clear: 'Clear', 'Reload', 'ReloadLayers'
 # See all open layers: 'GetLoadedLayers'
 from pxr import Sdf
+import os
 layer = Sdf.Layer.CreateAnonymous()
 ## The .CreateNew command will check if the layer is saveable at the file location and create an empty file.
 layer_file_path = os.path.expanduser("~/Desktop/layer_identifier_example.usd")

--- a/docs/src/pages/core/composition/fundamentals.md
+++ b/docs/src/pages/core/composition/fundamentals.md
@@ -21,7 +21,7 @@ If you detect an error or have useful production examples, please [submit a tick
 
 ## TL;DR - Composition Fundamentals In-A-Nutshell <a name="summary"></a>
 - Composition editing works in the active [layer stack](#compositionFundamentalsLayerStack) via [list editable ops](#compositionFundamentalsListEditableOps). 
-- When loading a layer (stack) from disk via `Reference` and `Payload` arcs, the contained composition structure is immutable (USD speak [encapsulated](#compositionFundamentalsEncapsulation)). This means you can't remove the arcs within the loaded files. As for what the arcs can use for value resolution: The `Inherit` and `Specialize` arcs still target the "live" composed stage and therefore still reflect changes on top of the encapsulated arcs, the `Reference` arc is limited to seeing the encapsulated layer stack.
+- When loading a layer (stack) from disk via `Reference` and `Payload` arcs, the contained composition structure is immutable (USD speak [encapsulated](#compositionFundamentalsEncapsulation)). This means you can't remove the arcs within the loaded files. As for what the arcs can use for value resolution: The `Inherit` and `Specialize` arcs still target the "live" composed stage and therefore still reflect changes on top of the encapsulated arcs, while the `Reference` arc is limited to seeing the encapsulated layer stack.
 
 ## Why should I understand the editing fundamentals? <a name="usage"></a>
 ~~~admonish tip

--- a/docs/src/pages/core/composition/livrps.md
+++ b/docs/src/pages/core/composition/livrps.md
@@ -250,7 +250,7 @@ If you want to create/edit sublayer arcs via code, see our [Composition Arc - Co
 Let's look at how sublayers are used in native USD:
 
 When creating a stage we have two layers by default:
-- **Session Layer**: This is a temp layer than doesn't get applied on disk save. Here we usually put things like viewport overrides.
+- **Session Layer**: This is a temp layer that doesn't get applied on disk save. Here we usually put things like viewport overrides.
 - **Root Layer**: This is the base layer all edits target by default. We can add sublayers based on what we need to it. When calling `stage.Save()`, all sublayers that are dirty and not anonymous, will be saved. 
 
 How are sublayers setup in Houdini?

--- a/docs/src/pages/core/elements/animation.md
+++ b/docs/src/pages/core/elements/animation.md
@@ -116,7 +116,7 @@ Usually we'll only have one or the other, it is quite common to run into this at
 ~~~
 
 ### Time Code <a name="animationTimeCode"></a>
-The `Usd.TimeCode` class is a small wrapper class for handling time encoding. Currently it does nothing more that storing if it is a `default` time code or a `time/frame` time code with a specific frame. In the future it may get the concept of encoding in `time` instead of `frame`, so to future proof your code, you should always use this class instead of setting a time value directly.
+The `Usd.TimeCode` class is a small wrapper class for handling time encoding. Currently it does nothing more than storing if it is a `default` time code or a `time/frame` time code with a specific frame. In the future it may get the concept of encoding in `time` instead of `frame`, so to future proof your code, you should always use this class instead of setting a time value directly.
 
 ~~~admonish info title=""
 ```python

--- a/docs/src/pages/core/elements/animation.md
+++ b/docs/src/pages/core/elements/animation.md
@@ -278,7 +278,7 @@ Stitching multiple files to a single file is usually used for small per frame US
 A typical production use case we use it for, is rendering out the render USD files per frame and then stitching these, as these are usually a few mb per frame at most.
 
 ~~~admonish warning
-When working with collections, make sure that they are not to big, by selecting parent prims where possible. Currently USD stitches target path lists a bit inefficiently, which will result in your stitching either not going through at all or taking forever. See our [collections](../composition/relationships.md) section for more details.
+When working with collections, make sure that they are not too big, by selecting parent prims where possible. Currently USD stitches target path lists a bit inefficiently, which will result in your stitching either not going through at all or taking forever. See our [collections](../composition/relationships.md) section for more details.
 ~~~
 
 USD ships with a standalone `usdstitch` commandline tool, which is a small Python wrapper around the `UsdUtils.StitchLayers()` function. You can read more it in our [standalone tools](./standalone_utilities.md) section.

--- a/docs/src/pages/core/elements/layer.md
+++ b/docs/src/pages/core/elements/layer.md
@@ -42,7 +42,7 @@ Layers and stages are the main entry point to accessing our data stored in USD.
 **Stages**
 - A stage is a view of a set of composed layers. You can think of it as the viewer in a view--model design. Each layer that the stage opens is a data source to the data model. When "asking" the stage for data, we ask the view for the combined (composed) data, which then queries into the layers based on the value source found by our composition rules.
 - When creating a stage we have two layers by default:
-    - **Session Layer**: This is a temp layer than doesn't get applied on disk save. Here we usually put things like viewport overrides.
+    - **Session Layer**: This is a temp layer that doesn't get applied on disk save. Here we usually put things like viewport overrides.
     - **Root Layer**: This is the base layer all edits target by default. We can add sublayers based on what we need to it. When calling `stage.Save()`, all sublayers that are dirty and not anonymous, will be saved. 
 
 ## What should I use it for? <a name="usage"></a>
@@ -327,7 +327,7 @@ Unlike layers, stages are not managed via a singleton. There is the [Usd.StageCa
 If a stage goes out of scope in our code, it will be deleted. Should we still have access the to Python object, we can check if it actually points to a valid layer via the `stage.expired` property.
 
 When creating a stage we have two layers by default:
-- **Session Layer**: This is a temp layer than doesn't get applied on disk save. Here we usually put things like viewport overrides.
+- **Session Layer**: This is a temp layer that doesn't get applied on disk save. Here we usually put things like viewport overrides.
 - **Root Layer**: This is the base layer all edits target by default. We can add sublayers based on what we need to it. When calling `stage.Save()`, all sublayers that are dirty and not anonymous, will be saved. 
 
 
@@ -439,7 +439,7 @@ Stages control:
 
 ### Stage Layer Management (Creation/Save/Export) <a name="stageLayerManagement"></a>
 When creating a stage we have two layers by default:
-- **Session Layer**: This is a temp layer than doesn't get applied on disk save. Here we usually put things like viewport overrides.
+- **Session Layer**: This is a temp layer that doesn't get applied on disk save. Here we usually put things like viewport overrides.
 - **Root Layer**: This is the base layer all edits target by default. We can add sublayers based on what we need to it. When calling `stage.Save()`, all sublayers that are dirty and not anonymous, will be saved. 
 
 Let's first look at layer access, there are two methods of special interest to us:

--- a/docs/src/pages/core/elements/layer.md
+++ b/docs/src/pages/core/elements/layer.md
@@ -430,7 +430,7 @@ In Houdini we don't have to manage this, it is always the highest layer in the a
 More info about edit targets in our [composition fundamentals](../composition/fundamentals.md) section.
 
 ### Loading mechanisms <a name="stageLoadingMechanisms"></a>
-Stages are the controller of how our [Prim Cache Population (PCP)](../composition/pcp.md) cache loads our composed layers. We cover this in detail in our [Traversing/Loading Data](./loading_mechanisms.md) section. Technically the stage just exposes the PCP cache in a nice API, that forwards its requests to the its pcp cache `stage._GetPcpCache()`, similar how all `Usd` ops are wrappers around `Sdf` calls.
+Stages are the controller of how our [Prim Cache Population (PCP)](../composition/pcp.md) cache loads our composed layers. We cover this in detail in our [Traversing/Loading Data](./loading_mechanisms.md) section. Technically the stage just exposes the PCP cache in a nice API, that forwards its requests to its PCP cache `stage._GetPcpCache()`, similar how all `Usd` ops are wrappers around `Sdf` calls.
 
 Stages control:
 - **Layer Muting**: This controls what layers are allowd to contribute to the composition result.

--- a/docs/src/pages/core/elements/layer.md
+++ b/docs/src/pages/core/elements/layer.md
@@ -250,7 +250,7 @@ For more info on composition arcs (especially the sublayer arc) see our [Composi
 
 
 #### Default Prim
-As discussed in more detail in our [composition](../composition/overview.md) section, the default prim specifies the default root prim to import via reference and payload arcs. If it is not specified, the first prim in the layer is used, that is not [abstract](./prim.md#primSpecifier) (not a prim with a class specifier) and that is [defined](./prim.md#primSpecifier) (has a `Sdf.SpecifierDef` define specifier), unless we specify them explicitly. We cannot specify nested prim paths, the path must be in the root (`Sdf.Path("/example").IsRootPrimPath()` must return `True`), setting an invalid path will not error, but it will not working when referencing/payloading the file.
+As discussed in more detail in our [composition](../composition/overview.md) section, the default prim specifies the default root prim to import via reference and payload arcs. If it is not specified, the first prim in the layer is used, that is not [abstract](./prim.md#primSpecifier) (not a prim with a class specifier) and that is [defined](./prim.md#primSpecifier) (has a `Sdf.SpecifierDef` define specifier), unless we specify them explicitly. We cannot specify nested prim paths, the path must be in the root (`Sdf.Path("/example").IsRootPrimPath()` must return `True`). Setting an invalid path will not cause an error, but it will not work when referencing or payloading the file.
 
 We typically use this in asset layers to specify the root prim that is the asset.
 

--- a/docs/src/pages/core/elements/layer.md
+++ b/docs/src/pages/core/elements/layer.md
@@ -103,7 +103,7 @@ for layer in Sdf.Layer.GetLoadedLayers():
 ```
 ~~~
 
-If a layer is not used anymore in a stage and goes out of scope in our code, it will be deleted. Should we still have access the to Python object, we can check if it actually points to a valid layer via the `layer.expired` property.
+If a layer is no longer used in a stage and goes out of scope in our code, it will be deleted. If we still have access to the Python object, we can check whether it points to a valid layer using the `layer.expired` property.
 
 As also mentioned in the next section, the layer identifier is made up of the URI(Unique Resource Identifier) and optional arguments. The layer identifier includes the optional args. This is on purpose, because different args can potentially mean a different file.
 

--- a/docs/src/pages/core/elements/layer.md
+++ b/docs/src/pages/core/elements/layer.md
@@ -215,7 +215,7 @@ The `metersPerUnit` and `upAxis` are only intent hints, it is up to the applicat
 The time related metrics should be written into all layers, as we can then use them to quickly inspect time related data in the file without having to fully parse it.
 
 ### Permissions <a name="layerPermissions"></a>
-We can lock a layer to not have editing or save permissions. Depending on the DCC, this is automatically done for your depending on how you access the stage, some applications leave this up to the user though.
+We can lock a layer to not allow editing or save permissions. Depending on the DCC, this is automatically done for you depending on how you access the stage. However, some applications leave this up to the user.
 
 Anonymous layers can't be saved to disk, therefore for them `layer.permissionToSave` is always `False`.
 

--- a/docs/src/pages/core/elements/loading_mechanisms.md
+++ b/docs/src/pages/core/elements/loading_mechanisms.md
@@ -23,7 +23,7 @@ There are three ways to influence the data load, from lowest to highest granular
 - **Prim Population Mask**: This controls what prim paths to consider for loading at all.
 - **Payload Loading**: This controls what prim paths, that have payloads, to load.
 - **GeomModelAPI->Draw Mode**: This controls per prim how it should be drawn by delegates. It can be one of "Full Geometry"/"Origin Axes"/"Bounding Box"/"Texture Cards". It requires the kind to be set on the prim and all its ancestors. Therefore it is "limited" to (asset-) root prims and ancestors.
-- **Activation**: Control per prim whether load itself and its child hierarchy. This is more a an artist facing mechanism, as we end up writing the data to the stage, which we don't do with the other methods.
+- **Activation**: Control per prim whether load itself and its child hierarchy. This is more an artist facing mechanism, as we end up writing the data to the stage, which we don't do with the other methods.
 
 #### Traversing/Iterating over our stage/layer
 To inspect our stage, we can iterate (traverse) over it:
@@ -72,7 +72,7 @@ There are three ways to influence the data load, from lowest to highest granular
 - **Prim Population Mask**: This controls what prim paths to consider for loading at all.
 - **Payload Loading**: This controls what prim paths, that have payloads, to load.
 - **GeomModelAPI->Draw Mode**: This controls per prim how it should be drawn by delegates. It can be one of "Full Geometry"/"Origin Axes"/"Bounding Box"/"Texture Cards". It requires the kind to be set on the prim and all its ancestors. Therefore it is "limited" to (asset-) root prims and ancestors.
-- **Activation**: Control per prim whether load itself and its child hierarchy. This is more a an artist facing mechanism, as we end up writing the data to the stage, which we don't do with the other methods.
+- **Activation**: Control per prim whether load itself and its child hierarchy. This is more an artist facing mechanism, as we end up writing the data to the stage, which we don't do with the other methods.
 
 Stages are the controller of how our [Prim Cache Population (PCP)](../composition/pcp.md) cache loads our composed layers. Technically the stage just exposes the PCP cache in a nice API, that forwards its requests to the its pcp cache `stage._GetPcpCache()`, similar how all `Usd` ops are wrappers around `Sdf` calls.
 

--- a/docs/src/pages/core/elements/loading_mechanisms.md
+++ b/docs/src/pages/core/elements/loading_mechanisms.md
@@ -74,7 +74,7 @@ There are three ways to influence the data load, from lowest to highest granular
 - **GeomModelAPI->Draw Mode**: This controls per prim how it should be drawn by delegates. It can be one of "Full Geometry"/"Origin Axes"/"Bounding Box"/"Texture Cards". It requires the kind to be set on the prim and all its ancestors. Therefore it is "limited" to (asset-) root prims and ancestors.
 - **Activation**: Control per prim whether load itself and its child hierarchy. This is more an artist facing mechanism, as we end up writing the data to the stage, which we don't do with the other methods.
 
-Stages are the controller of how our [Prim Cache Population (PCP)](../composition/pcp.md) cache loads our composed layers. Technically the stage just exposes the PCP cache in a nice API, that forwards its requests to the its pcp cache `stage._GetPcpCache()`, similar how all `Usd` ops are wrappers around `Sdf` calls.
+Stages are the controller of how our [Prim Cache Population (PCP)](../composition/pcp.md) cache loads our composed layers. Technically the stage just exposes the PCP cache in a nice API, that forwards its requests to its PCP cache `stage._GetPcpCache()`, similar how all `Usd` ops are wrappers around `Sdf` calls.
 
 
 Houdini exposes all three in two different ways:

--- a/docs/src/pages/core/elements/metadata.md
+++ b/docs/src/pages/core/elements/metadata.md
@@ -87,7 +87,7 @@ Metadata is different in that it:
 - Is strongly typed via schemas, so you need to register a custom schema if you want custom keys. This way we can ensure fallback values/documentation per key/value and avoid random data flying through your pipelines. For example all your mesh attributes have metadata for exactly what type/role they must match.
 - There are two special metadata keys for prims:
     - `assetInfo`: Here you should dump asset related data. This is just a predefined standardized location all vendors/companies should adhere to when writing asset data that should be tracked.
-    - `customData`: Here you can dump any data you want, a kind of scratch space, so you don't need to add you own schema. If you catch yourself misusing it too much, you should probably generate your own schema.
+    - `customData`: Here you can dump any data you want, a kind of scratch space, so you don't need to add your own schema. If you catch yourself misusing it too much, you should probably generate your own schema.
 
 
 ~~~admonish tip
@@ -200,7 +200,7 @@ to manage the content of this list to be synced with the actual payload(s) conte
 ~~~
 
 #### Custom Data <a name="metadataCustomData"></a>
-The `customData` field can be for any data you want, a kind of scratch space, so you don't need to add you own schema. If you catch yourself misusing it too much, you should probably generate your own schema.
+The `customData` field can be for any data you want, a kind of scratch space, so you don't need to add your own schema. If you catch yourself misusing it too much, you should probably generate your own schema.
 ~~~admonish info title=""
 ```python
 {{#include ../../../../../code/core/elements.py:metadataCustomData}}

--- a/docs/src/pages/core/elements/property.md
+++ b/docs/src/pages/core/elements/property.md
@@ -118,7 +118,7 @@ Here is a comparison to when we create an attribute a float3 normal attribute in
 We talk about how animation works in our [animation](./animation.md) section.
 
 ~~~admonish important
-Attributes are the only part of USD than can encode time varying data.
+Attributes are the only part of USD that can encode time-varying data.
 ~~~
 
 ~~~admonish info title=""

--- a/docs/src/pages/core/elements/property.md
+++ b/docs/src/pages/core/elements/property.md
@@ -308,7 +308,7 @@ Now that we got the basics down, let's have a look at some common attributes (an
 #### Purpose <a name="attributePurpose"></a>
 The `purpose` is a special USD attribute that:
 - Affects certain scene traversal methods (e.g. [bounding box or xform cache lookups](../../production/caches.md) can be limited to a specific purpose).
-- Is a mechanism for Hydra (USD's render abstraction interface) to only pull in data with a specific purpose. Since any rendering (viewport or final image) is run via Hydra, this allows users to load in only prims tagged with a specific purpose. For example, the `pxr.UsdGeom.Tokens.preview` purpose is used for scene navigation and previewing only, while the ``UsdGeom.Tokens.render` purpose is used for final frame rendering.
+- Is a mechanism for Hydra (USD's render abstraction interface) to only pull in data with a specific purpose. Since any rendering (viewport or final image) is run via Hydra, this allows users to load in only prims tagged with a specific purpose. For example, the `pxr.UsdGeom.Tokens.preview` purpose is used for scene navigation and previewing only, while the `UsdGeom.Tokens.render` purpose is used for final frame rendering.
 - It is inherited (like [primvars](#the-primvars-primvars-namespace)) down the hierarchy. You won't see this in UIs unlike with primvars.
 
 ~~~admonish tip title="Pro Tip | Where to mark the purpose"

--- a/docs/src/pages/core/elements/property.md
+++ b/docs/src/pages/core/elements/property.md
@@ -308,7 +308,7 @@ Now that we got the basics down, let's have a look at some common attributes (an
 #### Purpose <a name="attributePurpose"></a>
 The `purpose` is a special USD attribute that:
 - Affects certain scene traversal methods (e.g. [bounding box or xform cache lookups](../../production/caches.md) can be limited to a specific purpose).
-- Is a mechanism for Hydra (USD's render abstraction interface) to only pull in data with a specific purpose. Since any rendering (viewport or final image) is run via Hydra, this allows users to load in only prims tagged with a specific purpose. For example the `pxr.UsdGeom.Tokens.preview` purpose is used for scene navigation and previewing only, while the ``UsdGeom.Tokens.render` purpose is used for final frame rendering.
+- Is a mechanism for Hydra (USD's render abstraction interface) to only pull in data with a specific purpose. Since any rendering (viewport or final image) is run via Hydra, this allows users to load in only prims tagged with a specific purpose. For example, the `pxr.UsdGeom.Tokens.preview` purpose is used for scene navigation and previewing only, while the ``UsdGeom.Tokens.render` purpose is used for final frame rendering.
 - It is inherited (like [primvars](#the-primvars-primvars-namespace)) down the hierarchy. You won't see this in UIs unlike with primvars.
 
 ~~~admonish tip title="Pro Tip | Where to mark the purpose"

--- a/docs/src/pages/core/plugins/overview.md
+++ b/docs/src/pages/core/plugins/overview.md
@@ -46,7 +46,7 @@ export PXR_PLUGINPATH_NAME=/my/cool/plugin/resources:${PXR_PLUGINPATH_NAME}
 set PXR_PLUGINPATH_NAME=/my/cool/plugin/resources:${PXR_PLUGINPATH_NAME}
 ```
 
-If you search you Usd installation, you'll find a few of these for different components of Usd. They are usually placed in a <Plugin Root>/resources folder as a common directory convention.
+If you search your Usd installation, you'll find a few of these for different components of Usd. They are usually placed in a <Plugin Root>/resources folder as a common directory convention.
 
 Via Python you can also partially search for plugins (depending on what registry they are in) and also print their plugInfo.json file content via the `.metadata` attribute.
 

--- a/docs/src/pages/production/prerequisites.md
+++ b/docs/src/pages/production/prerequisites.md
@@ -17,7 +17,7 @@ Plugins (Covered in our [plugins](../core/plugins/overview.md) section):
 
 Data IO and Data Flow:
 - As a pipeline/software developer the core thing that has to work is data IO. This is something a user should never have to think about. What does this mean for you:
-    - Make sure your UX experience isn't to far from what artists already know.
+    - Make sure your UX experience isn't too far from what artists already know.
 - Make sure that your system of tracking layers and how your assets/shots are structured is solid enough to handle these cases:
     - Assets with different layers (model/material/fx/lighting)
     - FX (Asset and Shot FX, also make sure that you can also track non USD dependencies, like .bgeo, via metadata/other means)


### PR DESCRIPTION
Hi, thank you for this great project! 👋
This pull request includes various fixes and improvements across multiple files, addressing both code logic and documentation clarity. I’ve aimed to keep changes focused and helpful — please let me know if anything should be adjusted.

## Code Logic Fixes
- In `code/core/composition.py`
  - Fixed a misleading example where sublayers were added to `root_layer` instead of `active_layer`, so the code now matches the intended explanation.

- In `code/core/elements.py`:
  - Updated `visibility_attr_spec` to use `UsdGeom.Tokens.visibility` instead of `UsdGeom.Tokens.purpose`.
  - Fixed an incorrect example where a relationship targeted the same prim instead of the intended external prim. Updated to use `box_prim_path` for clarity and correctness.
  - Renamed the attribute from `tire:size` to `tire:radius` to avoid duplicate name conflicts in the same prim during example creation.
  - Fixed `UsdGeom.Primvar.IsPrimvar(primvar)` output to correctly return `True`.

## Documentation Fixes
- Corrected typos and grammar (e.g., “than” → “that”, “to big” → “too big”).
- Cleaned up formatting inconsistencies in comments and code blocks for consistency and readability.

---
Thanks again for maintaining this project — happy to revise anything if needed!